### PR TITLE
feat: modernize layout design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,7 +20,6 @@
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background-color: var(--background);
+  font-family: var(--font-sans);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 text-gray-800`}
       >
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,27 +23,35 @@ export default function Home() {
   };
 
   return (
-    <main className="max-w-xl mx-auto p-4 flex flex-col gap-4">
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
-        <input
-          className="border p-2"
-          value={birthInfo}
-          onChange={(e) => setBirthInfo(e.target.value)}
-          placeholder="정묘년 계축월 신사일 계사시 / 남성"
-        />
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded"
-          disabled={loading}
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-6">
+        <h1 className="text-3xl font-semibold text-center">사주 분석</h1>
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 rounded-2xl bg-white/80 p-6 shadow-lg backdrop-blur"
         >
-          {loading ? "분석 중..." : "분석하기"}
-        </button>
-      </form>
-      {report && (
-        <div className="border p-4 rounded bg-gray-50">
-          <ReactMarkdown>{report}</ReactMarkdown>
-        </div>
-      )}
+          <input
+            className="w-full rounded-lg border border-gray-300 p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={birthInfo}
+            onChange={(e) => setBirthInfo(e.target.value)}
+            placeholder="정묘년 계축월 신사일 계사시 / 남성"
+          />
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-blue-600 py-2 font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+            disabled={loading}
+          >
+            {loading ? "분석 중..." : "분석하기"}
+          </button>
+        </form>
+        {report && (
+          <div className="rounded-2xl bg-white/80 p-6 shadow-lg backdrop-blur">
+            <ReactMarkdown className="whitespace-pre-wrap leading-relaxed">
+              {report}
+            </ReactMarkdown>
+          </div>
+        )}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- apply gradient background and modern base styling in root layout
- update global styles to use custom fonts and support gradient
- redesign home page with centered card UI and polished form and result display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for config: recommends adding Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68944c7f298c8328a16bad655da8d840