### PR TITLE
Enhance Saju page with decorative fortune icon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 
 export default function Home() {
@@ -25,7 +26,10 @@ export default function Home() {
   return (
     <main className="flex min-h-screen items-center justify-center p-4">
       <div className="w-full max-w-md space-y-6">
-        <h1 className="text-3xl font-semibold text-center">사주 분석</h1>
+        <div className="flex flex-col items-center space-y-2">
+          <Image src="/fortune.svg" alt="사주 아이콘" width={64} height={64} />
+          <h1 className="text-3xl font-semibold text-center">사주 분석</h1>
+        </div>
         <form
           onSubmit={handleSubmit}
           className="space-y-4 rounded-2xl bg-white/80 p-6 shadow-lg backdrop-blur"
@@ -57,7 +61,7 @@ export default function Home() {
           />
           <button
             type="submit"
-            className="w-full rounded-lg bg-blue-600 py-2 font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+            className="w-full rounded-lg bg-gradient-to-r from-blue-500 to-purple-600 py-2 font-medium text-white transition-colors hover:from-blue-600 hover:to-purple-700 disabled:opacity-50"
             disabled={loading}
           >
             {loading ? "분석 중..." : "분석하기"}

--- a/public/fortune.svg
+++ b/public/fortune.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#f472b6"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#grad)"/>
+  <path d="M32 15l5 11 12 1-9 8 3 12-11-6-11 6 3-12-9-8 12-1z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `fortune.svg` asset for a fortune-themed icon
- display the new icon above the page title and update submit button with a gradient

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689466ceea908328acc5591de17e5e18