### PR TITLE
feat: add fancy date-time picker with Korean format

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "react-datepicker/dist/react-datepicker.css";
 
 :root {
   --background: #ffffff;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,22 +4,29 @@ import { useState } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import { manseCalc } from "@/lib/manse";
+import DatePicker, { registerLocale } from "react-datepicker";
+import { ko } from "date-fns/locale";
+
+registerLocale("ko", ko);
 
 export default function Home() {
-  const [birthDate, setBirthDate] = useState("");
-  const [birthTime, setBirthTime] = useState("");
+  const [birthDateTime, setBirthDateTime] = useState<Date | null>(null);
   const [manse, setManse] =
     useState<{ year: string; month: string; day: string; hour: string } | null>(
       null
     );
   const [loading, setLoading] = useState(false);
   const [report, setReport] = useState("");
+  const [buttonText, setButtonText] = useState("확인");
 
   const handleCalculate = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!birthDate || !birthTime) return;
-    const [y, m, d] = birthDate.split("-").map(Number);
-    const [hh, mm] = birthTime.split(":").map(Number);
+    if (!birthDateTime) return;
+    const y = birthDateTime.getFullYear();
+    const m = birthDateTime.getMonth() + 1;
+    const d = birthDateTime.getDate();
+    const hh = birthDateTime.getHours();
+    const mm = birthDateTime.getMinutes();
     const result = manseCalc(y, m, d, hh, mm);
     setManse(result);
     setReport("");
@@ -28,6 +35,8 @@ export default function Home() {
   const handleConfirm = async () => {
     if (!manse) return;
     setLoading(true);
+    setButtonText("상세한 분석을 위해 시간이 오래걸립니다.");
+    setTimeout(() => setButtonText("분석 중..."), 1000);
     const birthInfo = `${manse.year}년 ${manse.month}월 ${manse.day}일 ${manse.hour}시`;
     const res = await fetch("/api/saju", {
       method: "POST",
@@ -37,6 +46,7 @@ export default function Home() {
     const data = await res.json();
     setReport(data.result || data.error);
     setLoading(false);
+    setButtonText("확인");
   };
 
   return (
@@ -52,17 +62,15 @@ export default function Home() {
           onSubmit={handleCalculate}
           className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30"
         >
-          <input
-            type="date"
+          <DatePicker
+            selected={birthDateTime}
+            onChange={(date: Date | null) => setBirthDateTime(date)}
+            showTimeSelect
+            timeIntervals={30}
+            timeFormat="HH:mm"
+            dateFormat="MMMM/yy/dd HH:mm"
+            locale="ko"
             className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
-            value={birthDate}
-            onChange={(e) => setBirthDate(e.target.value)}
-          />
-          <input
-            type="time"
-            className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
-            value={birthTime}
-            onChange={(e) => setBirthTime(e.target.value)}
           />
           <button
             type="submit"
@@ -81,7 +89,7 @@ export default function Home() {
               className="w-full rounded-lg bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 py-2 font-medium text-white shadow-lg transition-colors hover:from-fuchsia-600 hover:via-rose-600 hover:to-amber-500 disabled:opacity-50"
               disabled={loading}
             >
-              {loading ? "분석 중..." : "확인"}
+              {buttonText}
             </button>
           </div>
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "date-fns": "^4.1.0",
         "next": "15.4.5",
         "openai": "^5.12.0",
         "react": "19.1.0",
+        "react-datepicker": "^8.4.0",
         "react-dom": "19.1.0",
         "react-markdown": "^10.1.0"
       },
@@ -59,6 +61,59 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.15",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.15.tgz",
+      "integrity": "sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.5",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.5.tgz",
+      "integrity": "sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.3",
@@ -1134,6 +1189,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -1194,6 +1258,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2520,6 +2594,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.4.0.tgz",
+      "integrity": "sha512-6nPDnj8vektWCIOy9ArS3avus9Ndsyz5XgFCJ7nBxXASSpBdSL6lG9jzNNmViPOAOPh6T5oJyGaXuMirBLECag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.3",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -2737,6 +2826,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "date-fns": "^4.1.0",
     "next": "15.4.5",
     "openai": "^5.12.0",
     "react": "19.1.0",
+    "react-datepicker": "^8.4.0",
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0"
   },


### PR DESCRIPTION
## Summary
- replace basic inputs with React DatePicker to pick date and time in Korean format
- show temporary notice message on analysis start
- include react-datepicker styles and dependencies

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_6895a6dd91e88328988a4c2f5a3cf5f6