### PR TITLE
feat: add custom Korean date picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,18 @@ To learn more about Next.js, take a look at the following resources:
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## DateTimePicker Component
+
+A custom Korean date picker is available for entering dates as `yyyy-mm-dd` or typing `20250808`. It also provides a calendar popup that stays in sync with the input.
+
+```tsx
+import DateTimePicker from "@/app/components/DateTimePicker";
+import { useState } from "react";
+
+function Example() {
+  const [date, setDate] = useState("");
+  return <DateTimePicker value={date} onChange={setDate} />;
+}
+```
+

--- a/app/components/DateTimePicker.tsx
+++ b/app/components/DateTimePicker.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dayjs, { Dayjs } from "dayjs";
+
+interface DateTimePickerProps {
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+export default function DateTimePicker({ value = "", onChange }: DateTimePickerProps) {
+  const [inputValue, setInputValue] = useState<string>(() => {
+    return value ? dayjs(value).format("YYYY-MM-DD") : "";
+  });
+  const [selectedDate, setSelectedDate] = useState<Dayjs | null>(() => {
+    return value ? dayjs(value) : null;
+  });
+  const [isOpen, setIsOpen] = useState(false);
+  const [calendarMonth, setCalendarMonth] = useState<Dayjs>(() => {
+    return value ? dayjs(value) : dayjs();
+  });
+
+  useEffect(() => {
+    if (selectedDate) {
+      const formatted = selectedDate.format("YYYY-MM-DD");
+      setInputValue(formatted);
+      setCalendarMonth(selectedDate);
+      onChange?.(formatted);
+    }
+  }, [selectedDate, onChange]);
+
+  useEffect(() => {
+    if (value) {
+      const parsed = dayjs(value);
+      if (parsed.isValid()) {
+        setSelectedDate(parsed);
+        setInputValue(parsed.format("YYYY-MM-DD"));
+        setCalendarMonth(parsed);
+      }
+    }
+  }, [value]);
+
+  const parseAndSet = (raw: string) => {
+    const digits = raw.replace(/-/g, "");
+    if (digits.length === 8) {
+      const parsed = dayjs(digits, "YYYYMMDD", true);
+      if (parsed.isValid()) {
+        setSelectedDate(parsed);
+      }
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setInputValue(val);
+    parseAndSet(val);
+  };
+
+  const handleInputBlur = () => {
+    const digits = inputValue.replace(/-/g, "");
+    const parsed = dayjs(digits, "YYYYMMDD", true);
+    if (parsed.isValid()) {
+      setSelectedDate(parsed);
+    } else if (selectedDate) {
+      setInputValue(selectedDate.format("YYYY-MM-DD"));
+    } else {
+      setInputValue("");
+    }
+  };
+
+  const selectDay = (date: Dayjs) => {
+    setSelectedDate(date);
+    setIsOpen(false);
+  };
+
+  const daysInMonth = calendarMonth.daysInMonth();
+  const firstDay = calendarMonth.startOf("month").day();
+  const calendarDays: (Dayjs | null)[] = [];
+  for (let i = 0; i < firstDay; i++) calendarDays.push(null);
+  for (let d = 1; d <= daysInMonth; d++) {
+    calendarDays.push(calendarMonth.date(d));
+  }
+
+  const weekDays = ["일", "월", "화", "수", "목", "금", "토"];
+
+  return (
+    <div className="relative inline-block w-full text-black">
+      <div className="flex gap-2">
+        <input
+          className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+          value={inputValue}
+          onChange={handleInputChange}
+          onBlur={handleInputBlur}
+          placeholder="yyyy-mm-dd"
+        />
+        <button
+          type="button"
+          className="rounded bg-gray-200 px-3 py-2"
+          onClick={() => setIsOpen((o) => !o)}
+        >
+          📅
+        </button>
+      </div>
+      {isOpen && (
+        <div className="absolute z-10 mt-2 rounded border bg-white p-2 shadow">
+          <div className="mb-2 flex items-center justify-between">
+            <button
+              type="button"
+              className="px-2"
+              onClick={() => setCalendarMonth(calendarMonth.subtract(1, "month"))}
+            >
+              ‹
+            </button>
+            <span>{calendarMonth.format("YYYY-MM")}</span>
+            <button
+              type="button"
+              className="px-2"
+              onClick={() => setCalendarMonth(calendarMonth.add(1, "month"))}
+            >
+              ›
+            </button>
+          </div>
+          <div className="grid grid-cols-7 gap-1 text-center">
+            {weekDays.map((d) => (
+              <div key={d} className="text-sm font-semibold">
+                {d}
+              </div>
+            ))}
+            {calendarDays.map((day, idx) => {
+              const isSelected = day && selectedDate && day.isSame(selectedDate, "day");
+              return (
+                <button
+                  key={idx}
+                  type="button"
+                  className={`h-8 w-8 rounded text-sm ${
+                    isSelected ? "bg-blue-500 text-white" : "hover:bg-gray-200"
+                  }`}
+                  onClick={() => day && selectDay(day)}
+                >
+                  {day ? day.date() : ""}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
+import DateTimePicker from "@/app/components/DateTimePicker";
 import { manseCalc } from "@/lib/manse";
 
 export default function Home() {
@@ -52,12 +53,7 @@ export default function Home() {
           onSubmit={handleCalculate}
           className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30"
         >
-          <input
-            type="date"
-            className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
-            value={birthDate}
-            onChange={(e) => setBirthDate(e.target.value)}
-          />
+          <DateTimePicker value={birthDate} onChange={setBirthDate} />
           <input
             type="time"
             className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "dayjs": "^1.11.13",
         "next": "15.4.5",
         "openai": "^5.12.0",
         "react": "19.1.0",
@@ -1193,6 +1194,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "dayjs": "^1.11.13",
     "next": "15.4.5",
     "openai": "^5.12.0",
     "react": "19.1.0",


### PR DESCRIPTION
## Summary
- add `dayjs` dependency
- implement `DateTimePicker` component with text input and popup calendar
- replace date input on main page with the new component and document usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895bc4c00bc8328a82d4f5d3ebcd844