### PR TITLE
Use native date picker and add gender selection

### DIFF
--- a/app/components/DateTimePicker.tsx
+++ b/app/components/DateTimePicker.tsx
@@ -1,150 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import dayjs, { Dayjs } from "dayjs";
-
 interface DateTimePickerProps {
   value?: string;
   onChange?: (value: string) => void;
 }
 
 export default function DateTimePicker({ value = "", onChange }: DateTimePickerProps) {
-  const [inputValue, setInputValue] = useState<string>(() => {
-    return value ? dayjs(value).format("YYYY-MM-DD") : "";
-  });
-  const [selectedDate, setSelectedDate] = useState<Dayjs | null>(() => {
-    return value ? dayjs(value) : null;
-  });
-  const [isOpen, setIsOpen] = useState(false);
-  const [calendarMonth, setCalendarMonth] = useState<Dayjs>(() => {
-    return value ? dayjs(value) : dayjs();
-  });
-
-  useEffect(() => {
-    if (selectedDate) {
-      const formatted = selectedDate.format("YYYY-MM-DD");
-      setInputValue(formatted);
-      setCalendarMonth(selectedDate);
-      onChange?.(formatted);
-    }
-  }, [selectedDate, onChange]);
-
-  useEffect(() => {
-    if (value) {
-      const parsed = dayjs(value);
-      if (parsed.isValid()) {
-        setSelectedDate(parsed);
-        setInputValue(parsed.format("YYYY-MM-DD"));
-        setCalendarMonth(parsed);
-      }
-    }
-  }, [value]);
-
-  const parseAndSet = (raw: string) => {
-    const digits = raw.replace(/-/g, "");
-    if (digits.length === 8) {
-      const parsed = dayjs(digits, "YYYYMMDD", true);
-      if (parsed.isValid()) {
-        setSelectedDate(parsed);
-      }
-    }
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value;
-    setInputValue(val);
-    parseAndSet(val);
-  };
-
-  const handleInputBlur = () => {
-    const digits = inputValue.replace(/-/g, "");
-    const parsed = dayjs(digits, "YYYYMMDD", true);
-    if (parsed.isValid()) {
-      setSelectedDate(parsed);
-    } else if (selectedDate) {
-      setInputValue(selectedDate.format("YYYY-MM-DD"));
-    } else {
-      setInputValue("");
-    }
-  };
-
-  const selectDay = (date: Dayjs) => {
-    setSelectedDate(date);
-    setIsOpen(false);
-  };
-
-  const daysInMonth = calendarMonth.daysInMonth();
-  const firstDay = calendarMonth.startOf("month").day();
-  const calendarDays: (Dayjs | null)[] = [];
-  for (let i = 0; i < firstDay; i++) calendarDays.push(null);
-  for (let d = 1; d <= daysInMonth; d++) {
-    calendarDays.push(calendarMonth.date(d));
-  }
-
-  const weekDays = ["일", "월", "화", "수", "목", "금", "토"];
-
   return (
-    <div className="relative inline-block w-full text-black">
-      <div className="flex gap-2">
-        <input
-          className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
-          value={inputValue}
-          onChange={handleInputChange}
-          onBlur={handleInputBlur}
-          placeholder="yyyy-mm-dd"
-        />
-        <button
-          type="button"
-          className="rounded bg-gray-200 px-3 py-2"
-          onClick={() => setIsOpen((o) => !o)}
-        >
-          📅
-        </button>
-      </div>
-      {isOpen && (
-        <div className="absolute z-10 mt-2 rounded border bg-white p-2 shadow">
-          <div className="mb-2 flex items-center justify-between">
-            <button
-              type="button"
-              className="px-2"
-              onClick={() => setCalendarMonth(calendarMonth.subtract(1, "month"))}
-            >
-              ‹
-            </button>
-            <span>{calendarMonth.format("YYYY-MM")}</span>
-            <button
-              type="button"
-              className="px-2"
-              onClick={() => setCalendarMonth(calendarMonth.add(1, "month"))}
-            >
-              ›
-            </button>
-          </div>
-          <div className="grid grid-cols-7 gap-1 text-center">
-            {weekDays.map((d) => (
-              <div key={d} className="text-sm font-semibold">
-                {d}
-              </div>
-            ))}
-            {calendarDays.map((day, idx) => {
-              const isSelected = day && selectedDate && day.isSame(selectedDate, "day");
-              return (
-                <button
-                  key={idx}
-                  type="button"
-                  className={`h-8 w-8 rounded text-sm ${
-                    isSelected ? "bg-blue-500 text-white" : "hover:bg-gray-200"
-                  }`}
-                  onClick={() => day && selectDay(day)}
-                >
-                  {day ? day.date() : ""}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </div>
+    <input
+      type="date"
+      className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+      value={value}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
   );
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { manseCalc } from "@/lib/manse";
 export default function Home() {
   const [birthDate, setBirthDate] = useState("");
   const [birthTime, setBirthTime] = useState("");
+  const [gender, setGender] = useState("");
   const [manse, setManse] =
     useState<{ year: string; month: string; day: string; hour: string } | null>(
       null
@@ -18,7 +19,7 @@ export default function Home() {
 
   const handleCalculate = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!birthDate || !birthTime) return;
+    if (!birthDate || !birthTime || !gender) return;
     const [y, m, d] = birthDate.split("-").map(Number);
     const [hh, mm] = birthTime.split(":").map(Number);
     const result = manseCalc(y, m, d, hh, mm);
@@ -27,9 +28,9 @@ export default function Home() {
   };
 
   const handleConfirm = async () => {
-    if (!manse) return;
+    if (!manse || !gender) return;
     setLoading(true);
-    const birthInfo = `${manse.year}년 ${manse.month}월 ${manse.day}일 ${manse.hour}시`;
+    const birthInfo = `${manse.year}년 ${manse.month}월 ${manse.day}일 ${manse.hour}시, 성별: ${gender}`;
     const res = await fetch("/api/saju", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -60,6 +61,15 @@ export default function Home() {
             value={birthTime}
             onChange={(e) => setBirthTime(e.target.value)}
           />
+          <select
+            className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+            value={gender}
+            onChange={(e) => setGender(e.target.value)}
+          >
+            <option value="">성별을 선택하세요</option>
+            <option value="남성">남성</option>
+            <option value="여성">여성</option>
+          </select>
           <button
             type="submit"
             className="w-full rounded-lg bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 py-2 font-medium text-white shadow-lg transition-colors hover:from-fuchsia-600 hover:via-rose-600 hover:to-amber-500"
@@ -70,7 +80,7 @@ export default function Home() {
         {manse && (
           <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 text-center">
             <p>
-              {manse.year}년 {manse.month}월 {manse.day}일 {manse.hour}시
+              {manse.year}년 {manse.month}월 {manse.day}일 {manse.hour}시 ({gender})
             </p>
             <button
               onClick={handleConfirm}


### PR DESCRIPTION
## Summary
- Replace custom calendar with native `<input type="date">`
- Add gender select field and include gender in analysis prompt

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895c1bae3bc8328b81ff46353b7fac3