### PR TITLE
Fix mobile date/time picker overflow

### DIFF
--- a/app/components/DateTimePicker.tsx
+++ b/app/components/DateTimePicker.tsx
@@ -9,7 +9,7 @@ export default function DateTimePicker({ value = "", onChange }: DateTimePickerP
   return (
     <input
       type="date"
-      className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+      className="w-full min-w-0 max-w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
       value={value}
       onChange={(e) => onChange?.(e.target.value)}
     />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ export default function Home() {
           <DateTimePicker value={birthDate} onChange={setBirthDate} />
           <input
             type="time"
-            className="w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+            className="w-full min-w-0 max-w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
             value={birthTime}
             onChange={(e) => setBirthTime(e.target.value)}
           />


### PR DESCRIPTION
## Summary
- prevent date and time inputs from overflowing their container on small screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895c443a8fc8328ba0ea360ff666c71