### PR TITLE
Ensure date/time inputs don't overflow in Safari

### DIFF
--- a/app/components/DateTimePicker.tsx
+++ b/app/components/DateTimePicker.tsx
@@ -9,7 +9,7 @@ export default function DateTimePicker({ value = "", onChange }: DateTimePickerP
   return (
     <input
       type="date"
-      className="block w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+      className="block w-full min-w-0 appearance-none rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
       value={value}
       onChange={(e) => onChange?.(e.target.value)}
     />

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,3 +40,9 @@ body {
   background-size: 200% 200%;
   animation: gradient 8s ease infinite;
 }
+input[type="date"],
+input[type="time"] {
+  width: 100%;
+  min-width: 0;
+  appearance: none;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ export default function Home() {
           <DateTimePicker value={birthDate} onChange={setBirthDate} />
           <input
             type="time"
-            className="block w-full rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+            className="block w-full min-w-0 appearance-none rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
             value={birthTime}
             onChange={(e) => setBirthTime(e.target.value)}
           />


### PR DESCRIPTION
## Summary
- Add `min-w-0` and `appearance-none` classes to date and time inputs
- Apply global CSS rule for date/time inputs to override Safari default sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895f4329b9c8328a3ed6522ee707409