### PR TITLE
Auto-calculate manse and streamline analysis flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import DateTimePicker from "@/app/components/DateTimePicker";
@@ -17,15 +17,18 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [report, setReport] = useState("");
 
-  const handleCalculate = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!birthDate || !birthTime || !gender) return;
-    const [y, m, d] = birthDate.split("-").map(Number);
-    const [hh, mm] = birthTime.split(":").map(Number);
-    const result = manseCalc(y, m, d, hh, mm);
-    setManse(result);
-    setReport("");
-  };
+  useEffect(() => {
+    if (birthDate && birthTime && gender) {
+      const [y, m, d] = birthDate.split("-").map(Number);
+      const [hh, mm] = birthTime.split(":").map(Number);
+      const result = manseCalc(y, m, d, hh, mm);
+      setManse(result);
+      setReport("");
+    } else {
+      setManse(null);
+      setReport("");
+    }
+  }, [birthDate, birthTime, gender]);
 
   const handleConfirm = async () => {
     if (!manse || !gender) return;
@@ -50,10 +53,7 @@ export default function Home() {
             사주 분석
           </h1>
         </div>
-        <form
-          onSubmit={handleCalculate}
-          className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30"
-        >
+        <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30">
           <DateTimePicker value={birthDate} onChange={setBirthDate} />
           <input
             type="time"
@@ -70,27 +70,21 @@ export default function Home() {
             <option value="남성">남성</option>
             <option value="여성">여성</option>
           </select>
-          <button
-            type="submit"
-            className="w-full rounded-lg bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 py-2 font-medium text-white shadow-lg transition-colors hover:from-fuchsia-600 hover:via-rose-600 hover:to-amber-500"
-          >
-            만세력 보기
-          </button>
-        </form>
+        </div>
         {manse && (
           <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 text-center">
             <p>
               {manse.year}년 {manse.month}월 {manse.day}일 {manse.hour}시 ({gender})
             </p>
-            <button
-              onClick={handleConfirm}
-              className="w-full rounded-lg bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 py-2 font-medium text-white shadow-lg transition-colors hover:from-fuchsia-600 hover:via-rose-600 hover:to-amber-500 disabled:opacity-50"
-              disabled={loading}
-            >
-              {loading ? "분석 중..." : "확인"}
-            </button>
           </div>
         )}
+        <button
+          onClick={handleConfirm}
+          className="w-full rounded-lg bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 py-2 font-medium text-white shadow-lg transition-colors hover:from-fuchsia-600 hover:via-rose-600 hover:to-amber-500 disabled:opacity-50"
+          disabled={!manse || loading}
+        >
+          {loading ? "분석 중..." : "분석"}
+        </button>
         {report && (
           <div className="rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 whitespace-pre-wrap leading-relaxed">
             <ReactMarkdown>{report}</ReactMarkdown>


### PR DESCRIPTION
## Summary
- Compute 사주 pillars automatically via useEffect when birth info is complete
- Remove manual calculation form and expose a single 분석 button
- Disable 분석 button until pillars are ready and keep existing API call logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895fdee2dc48328870288f04a6dfbae