### PR TITLE
feat: display four pillars in manse grid

### DIFF
--- a/app/components/ManseDisplay.tsx
+++ b/app/components/ManseDisplay.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+interface ManseDisplayProps {
+  manse: {
+    year: string;
+    month: string;
+    day: string;
+    hour: string;
+  };
+  gender: string;
+}
+
+export default function ManseDisplay({ manse, gender }: ManseDisplayProps) {
+  const parts = [
+    { label: "년", value: manse.year },
+    { label: "월", value: manse.month },
+    { label: "일", value: manse.day },
+    { label: "시", value: manse.hour },
+  ];
+
+  const colors: [string, string][] = [
+    ["bg-rose-200", "bg-rose-100"],
+    ["bg-orange-200", "bg-orange-100"],
+    ["bg-emerald-200", "bg-emerald-100"],
+    ["bg-sky-200", "bg-sky-100"],
+  ];
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-4 gap-2 text-gray-800">
+        {parts.map((part, idx) => {
+          const stem = part.value.charAt(0);
+          const branch = part.value.charAt(1);
+          const [topColor, bottomColor] = colors[idx];
+          return (
+            <div key={part.label} className="flex flex-col items-stretch text-center">
+              <div
+                className={`${topColor} w-full rounded-md px-2 py-3 text-3xl sm:text-4xl font-bold`}
+              >
+                {stem}
+              </div>
+              <div
+                className={`${bottomColor} w-full rounded-md px-2 py-3 text-3xl sm:text-4xl font-bold`}
+              >
+                {branch}
+              </div>
+              <span className="mt-1 text-xs text-gray-500 sm:text-sm">{part.label}</span>
+            </div>
+          );
+        })}
+      </div>
+      <p className="text-sm text-gray-200">{gender}</p>
+    </div>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import DateTimePicker from "@/app/components/DateTimePicker";
+import ManseDisplay from "@/app/components/ManseDisplay";
 import { manseCalc } from "@/lib/manse";
 
 export default function Home() {
@@ -73,9 +74,7 @@ export default function Home() {
         </div>
         {manse && (
           <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 text-center">
-            <p>
-              {manse.year}년 {manse.month}월 {manse.day}일 {manse.hour}시 ({gender})
-            </p>
+            <ManseDisplay manse={manse} gender={gender} />
           </div>
         )}
         <button


### PR DESCRIPTION
## Summary
- show year/month/day/hour stems and branches in a four-column pastel grid
- use ManseDisplay component in home page instead of plain text

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896002c1f3483288ffa8abadfdbd278