### PR TITLE
Reorder manse display to hour-first order

### DIFF
--- a/app/components/ManseDisplay.tsx
+++ b/app/components/ManseDisplay.tsx
@@ -12,10 +12,10 @@ interface ManseDisplayProps {
 
 export default function ManseDisplay({ manse, gender }: ManseDisplayProps) {
   const parts = [
-    { label: "년", value: manse.year },
-    { label: "월", value: manse.month },
-    { label: "일", value: manse.day },
     { label: "시", value: manse.hour },
+    { label: "일", value: manse.day },
+    { label: "월", value: manse.month },
+    { label: "년", value: manse.year },
   ];
 
   const elementColorMap: Record<string, string> = {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ export default function Home() {
   const handleConfirm = async () => {
     if (!manse || !gender) return;
     setLoading(true);
-    const birthInfo = `${manse.year}년 ${manse.month}월 ${manse.day}일 ${manse.hour}시, 성별: ${gender}`;
+    const birthInfo = `${manse.hour}시 ${manse.day}일 ${manse.month}월 ${manse.year}년, 성별: ${gender}`;
     const res = await fetch("/api/saju", {
       method: "POST",
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Display manse parts in hour→day→month→year sequence
- Align birthInfo string with new manse order

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689620fe89d48328a0775ce81a215bcf