### PR TITLE
feat: label cat mode toggle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,13 +74,18 @@ export default function Home() {
           </select>
         </div>
         <div className="flex justify-center">
-          <button
-            onClick={() => setCatMode((prev) => !prev)}
-            aria-pressed={catMode}
-            className={`text-4xl transition-transform duration-200 ${catMode ? "scale-125 rotate-6 drop-shadow-[0_0_6px_#facc15]" : "opacity-50"}`}
-          >
-            😺
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setCatMode((prev) => !prev)}
+              aria-pressed={catMode}
+              aria-label="냥냥체 인젝션"
+              title="냥냥체 인젝션"
+              className={`text-4xl transition-transform duration-200 ${catMode ? "scale-125 rotate-6 drop-shadow-[0_0_6px_#facc15]" : "opacity-50"}`}
+            >
+              😺
+            </button>
+            <span className="text-xs text-white/80">냥냥체 인젝션</span>
+          </div>
         </div>
         {manse && (
           <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 text-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,18 +74,20 @@ export default function Home() {
           </select>
         </div>
         <div className="flex justify-center">
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => setCatMode((prev) => !prev)}
-              aria-pressed={catMode}
-              aria-label="냥냥체 인젝션"
-              title="냥냥체 인젝션"
-              className={`text-4xl transition-transform duration-200 ${catMode ? "scale-125 rotate-6 drop-shadow-[0_0_6px_#facc15]" : "opacity-50"}`}
-            >
-              😺
-            </button>
-            <span className="text-xs text-white/80">냥냥체 인젝션</span>
-          </div>
+          <button
+            onClick={() => setCatMode((prev) => !prev)}
+            aria-pressed={catMode}
+            aria-label="냥냥체 인젝션"
+            title="냥냥체 인젝션"
+            className={`flex items-center gap-1 rounded-md border px-3 py-1 text-xs text-white/80 transition-colors ${
+              catMode
+                ? "border-white/40 bg-white/20"
+                : "border-white/20 bg-white/10 hover:bg-white/20"
+            }`}
+          >
+            <span className={`text-lg transition-opacity ${catMode ? "" : "opacity-50"}`}>😺</span>
+            <span>냥냥체 인젝션</span>
+          </button>
         </div>
         {manse && (
           <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 text-center">


### PR DESCRIPTION
## Summary
- add descriptive "냥냥체 인젝션" label beside cat mode toggle
- improve accessibility with aria and title attributes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689634998ea08328b5d25fb3d8e4863d