### PR TITLE
Arrange cat mode toggle beside analysis button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,7 +73,12 @@ export default function Home() {
             <option value="여성">여성</option>
           </select>
         </div>
-        <div className="flex justify-center">
+        {manse && (
+          <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 text-center">
+            <ManseDisplay manse={manse} gender={gender} />
+          </div>
+        )}
+        <div className="flex gap-2">
           <button
             onClick={() => setCatMode((prev) => !prev)}
             aria-pressed={catMode}
@@ -96,19 +101,14 @@ export default function Home() {
             </span>
             <span>냥냥체 인젝션</span>
           </button>
+          <button
+            onClick={handleConfirm}
+            className="flex-1 rounded-lg bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 py-2 font-medium text-white shadow-lg transition-colors hover:from-fuchsia-600 hover:via-rose-600 hover:to-amber-500 disabled:opacity-50"
+            disabled={!manse || loading}
+          >
+            {loading ? "분석 중..." : "분석"}
+          </button>
         </div>
-        {manse && (
-          <div className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 text-center">
-            <ManseDisplay manse={manse} gender={gender} />
-          </div>
-        )}
-        <button
-          onClick={handleConfirm}
-          className="w-full rounded-lg bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 py-2 font-medium text-white shadow-lg transition-colors hover:from-fuchsia-600 hover:via-rose-600 hover:to-amber-500 disabled:opacity-50"
-          disabled={!manse || loading}
-        >
-          {loading ? "분석 중..." : "분석"}
-        </button>
         {report && (
           <div className="rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 whitespace-pre-wrap leading-relaxed">
             <ReactMarkdown>{report}</ReactMarkdown>


### PR DESCRIPTION
## Summary
- Place cat-mode toggle and 분석 button in a shared flex container
- Allow 분석 button to grow with `flex-1` and keep cat toggle natural width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: asks "How would you like to configure ESLint?")*

------
https://chatgpt.com/codex/tasks/task_e_68964287ece08328bacd30313c3ea3a8