### PR TITLE
feat: add cat rain effect

### DIFF
--- a/app/components/CatRain.tsx
+++ b/app/components/CatRain.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface Cat {
+  id: number;
+  left: number; // percentage
+  size: number; // px
+  duration: number; // seconds
+  drift: number; // percentage horizontal drift
+}
+
+export default function CatRain({ active }: { active: boolean }) {
+  const [cats, setCats] = useState<Cat[]>([]);
+  const timeouts = useRef<NodeJS.Timeout[]>([]);
+
+  useEffect(() => {
+    if (!active) {
+      // clear any existing cats and timers when inactive
+      timeouts.current.forEach(clearTimeout);
+      timeouts.current = [];
+      setCats([]);
+      return;
+    }
+
+    const interval = setInterval(() => {
+      const id = Date.now() + Math.random();
+      const cat: Cat = {
+        id,
+        left: Math.random() * 100,
+        size: 24 + Math.random() * 32,
+        duration: 8 + Math.random() * 6,
+        drift: Math.random() * 100 - 50,
+      };
+      setCats((prev) => [...prev, cat]);
+
+      const timeout = setTimeout(() => {
+        setCats((prev) => prev.filter((c) => c.id !== id));
+      }, cat.duration * 1000);
+      timeouts.current.push(timeout);
+    }, 500);
+
+    return () => {
+      clearInterval(interval);
+      timeouts.current.forEach(clearTimeout);
+      timeouts.current = [];
+    };
+  }, [active]);
+
+  if (!active) return null;
+
+  return (
+    <div className="pointer-events-none fixed inset-0 overflow-hidden">
+      {cats.map((cat) => (
+        <span
+          key={cat.id}
+          className="absolute cat-fall"
+          style={{
+            left: `${cat.left}%`,
+            fontSize: `${cat.size}px`,
+            animationDuration: `${cat.duration}s`,
+            // @ts-ignore -- custom property for horizontal drift
+            "--drift": `${cat.drift}%`,
+          }}
+        >
+          🐱
+        </span>
+      ))}
+    </div>
+  );
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -46,3 +46,21 @@ input[type="time"] {
   min-width: 0;
   appearance: none;
 }
+
+@keyframes cat-fall {
+  0% {
+    transform: translate(0, -10%) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--drift, 0), 110vh) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+.cat-fall {
+  animation-name: cat-fall;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import DateTimePicker from "@/app/components/DateTimePicker";
 import ManseDisplay from "@/app/components/ManseDisplay";
+import CatRain from "@/app/components/CatRain";
 import { manseCalc } from "@/lib/manse";
 
 export default function Home() {
@@ -48,6 +49,7 @@ export default function Home() {
 
   return (
     <main className="flex min-h-screen items-center justify-center p-4 text-white">
+      <CatRain active={catMode} />
       <div className="w-full max-w-md space-y-6">
         <div className="flex flex-col items-center space-y-2">
           <Image src="/fortune.svg" alt="사주 아이콘" width={64} height={64} />


### PR DESCRIPTION
## Summary
- add `CatRain` component that spawns animated cat emojis when cat mode is active
- define `cat-fall` keyframes and styles for drifting animations
- render `CatRain` in `Home` page to overlay cat rain effect

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive ESLint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_689644bf2af08328a7cd3f55c2171f92