### PR TITLE
feat: add cat mode background toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,6 +22,19 @@
 body {
   background-color: var(--background);
   font-family: var(--font-sans);
+  position: relative;
+}
+
+body::before {
+  content: "";
+  @apply absolute inset-0 bg-gradient-to-br from-pink-900 via-rose-900 to-amber-700 opacity-0 transition-opacity duration-700 pointer-events-none;
+  z-index: -1;
+  background-size: 200% 200%;
+  animation: gradient 8s ease infinite;
+}
+
+body.cat-mode-bg::before {
+  @apply opacity-100;
 }
 
 @keyframes gradient {
@@ -41,9 +54,7 @@ body {
   animation: gradient 8s ease infinite;
 }
 
-.cat-mode-bg {
-  @apply bg-gradient-to-br from-pink-800 via-pink-300 to-yellow-400;
-}
+
 input[type="date"],
 input[type="time"] {
   width: 100%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -42,7 +42,7 @@ body {
 }
 
 .cat-mode-bg {
-  @apply bg-gradient-to-br from-pink-300 via-pink-200 to-yellow-200;
+  @apply bg-gradient-to-br from-pink-800 via-pink-300 to-yellow-400;
 }
 input[type="date"],
 input[type="time"] {

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,6 +40,10 @@ body {
   background-size: 200% 200%;
   animation: gradient 8s ease infinite;
 }
+
+.cat-mode-bg {
+  @apply bg-gradient-to-br from-pink-300 via-pink-200 to-yellow-200;
+}
 input[type="date"],
 input[type="time"] {
   width: 100%;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,17 @@ export default function Home() {
     }
   }, [birthDate, birthTime, gender]);
 
+  useEffect(() => {
+    if (catMode) {
+      document.body.classList.add("cat-mode-bg");
+    } else {
+      document.body.classList.remove("cat-mode-bg");
+    }
+    return () => {
+      document.body.classList.remove("cat-mode-bg");
+    };
+  }, [catMode]);
+
   const handleConfirm = async () => {
     if (!manse || !gender) return;
     setLoading(true);


### PR DESCRIPTION
## Summary
- add cat-mode pink-yellow gradient background style
- toggle body gradient when cat mode is enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for configuration)*
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68970fe999688328a884038b350b25e0