### PR TITLE
Enhance background gradient animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -27,10 +27,10 @@ body {
 
 body::before {
   content: "";
-  @apply absolute inset-0 bg-gradient-to-br from-pink-900 via-rose-900 to-amber-700 opacity-0 transition-opacity duration-700 pointer-events-none;
+  @apply absolute inset-0 bg-gradient-to-br from-pink-900 via-rose-900 via-purple-800 via-amber-700 to-yellow-600 opacity-0 transition-opacity duration-700 pointer-events-none;
   z-index: -1;
-  background-size: 200% 200%;
-  animation: gradient 8s ease infinite;
+  background-size: 300% 300%;
+  animation: gradient 4s linear infinite;
 }
 
 body.cat-mode-bg::before {
@@ -41,8 +41,14 @@ body.cat-mode-bg::before {
   0% {
     background-position: 0% 50%;
   }
+  25% {
+    background-position: 50% 100%;
+  }
   50% {
     background-position: 100% 50%;
+  }
+  75% {
+    background-position: 50% 0%;
   }
   100% {
     background-position: 0% 50%;
@@ -50,8 +56,8 @@ body.cat-mode-bg::before {
 }
 
 .animate-gradient {
-  background-size: 200% 200%;
-  animation: gradient 8s ease infinite;
+  background-size: 300% 300%;
+  animation: gradient 4s linear infinite;
 }
 
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased min-h-screen bg-gradient-to-br from-purple-900 via-fuchsia-900 to-pink-800 animate-gradient text-white">
+      <body className="antialiased min-h-screen bg-gradient-to-br from-purple-900 via-blue-800 via-fuchsia-700 via-pink-600 to-amber-500 animate-gradient text-white">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Expand body background gradient with multiple color stops and faster animation
- Mirror new gradient in cat-mode overlay with larger background size
- Introduce intermediate keyframe steps for swirling gradient movement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689729e29e208328a349ab66fcaff14f