### PR TITLE
chore: slow gradient animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -30,7 +30,7 @@ body::before {
   @apply absolute inset-0 bg-gradient-to-br from-pink-900 via-rose-900 via-purple-800 via-amber-700 to-yellow-600 opacity-0 transition-opacity duration-700 pointer-events-none;
   z-index: -1;
   background-size: 300% 300%;
-  animation: gradient 4s linear infinite;
+  animation: gradient 6.4s linear infinite;
 }
 
 body.cat-mode-bg::before {
@@ -57,7 +57,7 @@ body.cat-mode-bg::before {
 
 .animate-gradient {
   background-size: 300% 300%;
-  animation: gradient 8s linear infinite;
+  animation: gradient 12.8s linear infinite;
 }
 
 


### PR DESCRIPTION
## Summary
- slow gradient animation by about 60%

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_689732e51e088328ae117f23f7a5a91d