### PR TITLE
feat: add injection guard schema

### DIFF
--- a/app/api/saju/route.ts
+++ b/app/api/saju/route.ts
@@ -35,6 +35,14 @@ export async function POST(req: Request) {
     const response = await client.responses.create({
       model: "gpt-5",
       input: messages,
+      guard: {
+        schema: {
+          type: "object",
+          properties: { is_injection: { type: "boolean" } },
+          required: ["is_injection"],
+          additionalProperties: false,
+        },
+      },
     } as any);
 
     const output = response.output_text;


### PR DESCRIPTION
## Summary
- add prompt-injection guard schema to saju route

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68976663246c8328bb313071301072aa