### PR TITLE
Enforce four-digit year in DateTimePicker

### DIFF
--- a/app/components/DateTimePicker.tsx
+++ b/app/components/DateTimePicker.tsx
@@ -11,7 +11,16 @@ export default function DateTimePicker({ value = "", onChange }: DateTimePickerP
       type="date"
       className="block w-full min-w-0 appearance-none rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
       value={value}
-      onChange={(e) => onChange?.(e.target.value)}
+      onInput={(e) => {
+        const input = e.currentTarget;
+        const [year = "", month = "", day = ""] = input.value.split("-");
+        const trimmedYear = year.slice(0, 4);
+        const newValue = [trimmedYear, month, day].filter(Boolean).join("-");
+        if (newValue !== input.value) {
+          input.value = newValue;
+        }
+        onChange?.(newValue);
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- limit year input to four digits in `DateTimePicker` via `onInput`

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68977f4e035c83289ea5ca5db80e6f9f