### PR TITLE
Add max date limit to DateTimePicker

### DIFF
--- a/app/components/DateTimePicker.tsx
+++ b/app/components/DateTimePicker.tsx
@@ -10,6 +10,7 @@ export default function DateTimePicker({ value = "", onChange }: DateTimePickerP
     <input
       type="date"
       className="block w-full min-w-0 appearance-none rounded-lg border-none bg-white/90 p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-fuchsia-500"
+      max="9999-12-31"
       value={value}
       onChange={(e) => onChange?.(e.target.value)}
     />


### PR DESCRIPTION
## Summary
- cap date selection at year 9999 for DateTimePicker input

## Testing
- `npm run lint` *(fails: Invalid Options - Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_6897877411588328ab9c8faea25c5f0b