### PR TITLE
Handle duplicate line breaks in markdown output

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
+import remarkSqueezeParagraphs from "remark-squeeze-paragraphs";
 import DateTimePicker from "@/app/components/DateTimePicker";
 import ManseDisplay from "@/app/components/ManseDisplay";
 import CatRain from "@/app/components/CatRain";
@@ -134,7 +135,7 @@ export default function Home() {
         </div>
         {report && (
           <div className="rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 whitespace-pre-wrap leading-relaxed">
-            <ReactMarkdown>{report}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkSqueezeParagraphs]}>{report}</ReactMarkdown>
           </div>
         )}
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "openai": "^5.12.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "remark-squeeze-paragraphs": "^6.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1689,6 +1690,20 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/mdast-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-6NDbJPTg0M0Ye+TlYwX1KJ1LFbp515P2immRJyJQhc9Na9cetHzSoHNYIQcXpANEAP1sm9yd/CTZU2uHqR5A+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -2593,6 +2608,20 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-qOk1am0QjTGoCPsFuORIZteajsFzLV2m8ijOn3zX9Y0P0IE0lMgjzyP0BxICWnvNz3j+9B+LUNnLHquNu+IrBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-squeeze-paragraphs": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "openai": "^5.12.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "remark-squeeze-paragraphs": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- add `remark-squeeze-paragraphs` to collapse consecutive blank lines when rendering markdown

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68981f455ba48328a83dbbafb5ce8a30