### PR TITLE
Trim report text before rendering

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,7 +56,7 @@ export default function Home() {
       body: JSON.stringify({ birthInfo, catMode, question: extraQuestion }),
     });
     const data = await res.json();
-    setReport(data.result || data.error);
+    setReport((data.result || data.error).trim());
     setLoading(false);
   };
 


### PR DESCRIPTION
## Summary
- Trim trailing whitespace from API results before setting the report so markdown renders cleanly.

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run dev`
- `curl -sS -X POST http://localhost:3000/api/saju -H 'Content-Type: application/json' -d '{"birthInfo":"test","catMode":false,"question":""}'`


------
https://chatgpt.com/codex/tasks/task_e_68982c4002c083289899dc9628146635