### PR TITLE
feat: style markdown content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -86,3 +86,31 @@ input[type="time"] {
   animation-fill-mode: forwards;
 }
 
+.markdown h1 {
+  @apply mb-4 text-2xl font-bold;
+}
+
+.markdown h2 {
+  @apply mt-6 mb-2 text-xl font-semibold;
+}
+
+.markdown p {
+  @apply my-4 leading-relaxed;
+}
+
+.markdown ul {
+  @apply my-4 list-disc pl-6;
+}
+
+.markdown li {
+  @apply mb-1;
+}
+
+.markdown pre {
+  @apply my-4 overflow-x-auto rounded bg-black/80 p-4 text-sm;
+}
+
+.markdown code {
+  @apply rounded bg-black/50 px-1 py-0.5 font-mono text-sm;
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -143,7 +143,11 @@ export default function Home() {
             ref={reportRef}
             className="rounded-2xl bg-white/20 p-6 shadow-2xl backdrop-blur-md ring-1 ring-white/30 whitespace-pre-wrap leading-relaxed"
           >
-            <ReactMarkdown remarkPlugins={[remarkSqueezeParagraphs]}>{report}</ReactMarkdown>
+            <div className="markdown">
+              <ReactMarkdown remarkPlugins={[remarkSqueezeParagraphs]}>
+                {report}
+              </ReactMarkdown>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- wrap ReactMarkdown output in markdown container
- add Tailwind utilities for markdown elements

## Testing
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689861307a088328963e08201ecd0869