### PR TITLE
feat: persist saju results

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,14 @@
+export interface Manse {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+}
+
+export interface StoredResult {
+  name: string;
+  manse: Manse;
+  createdAt: string;
+  catMode: boolean;
+  model: string;
+}


### PR DESCRIPTION
## Summary
- add shared `Manse` and `StoredResult` interfaces
- keep a results history in localStorage
- hydrate history on mount and append new entries after fetching a report

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68987744a2988328bfde2efd12c2052b