### PR TITLE
Allow model selection via query parameter

### DIFF
--- a/app/api/saju/route.ts
+++ b/app/api/saju/route.ts
@@ -3,6 +3,8 @@ import OpenAI from "openai";
 
 export async function POST(req: Request) {
   try {
+    const { searchParams } = new URL(req.url);
+    const model = searchParams.get("model") || "gpt-5-mini";
     const { birthInfo, catMode, question } = await req.json();
     if (!birthInfo) {
       return NextResponse.json({ error: "Missing birthInfo" }, { status: 400 });
@@ -33,7 +35,7 @@ export async function POST(req: Request) {
       },
     ];
     const response = await client.responses.create({
-      model: "gpt-5",
+      model,
       input: messages,
     } as any);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import remarkSqueezeParagraphs from "remark-squeeze-paragraphs";
+import { useSearchParams } from "next/navigation";
 import DateTimePicker from "@/app/components/DateTimePicker";
 import ManseDisplay from "@/app/components/ManseDisplay";
 import CatRain from "@/app/components/CatRain";
@@ -22,6 +23,8 @@ export default function Home() {
   const [catMode, setCatMode] = useState(false);
   const [extraQuestion, setExtraQuestion] = useState("");
   const reportRef = useRef<HTMLDivElement>(null);
+  const searchParams = useSearchParams();
+  const model = searchParams.get("model") || "gpt-5-mini";
   interface StoredResult {
     id: string;
     name: string;
@@ -87,7 +90,7 @@ export default function Home() {
     if (!manse || !gender || !name) return;
     setLoading(true);
     const birthInfo = `${manse.hour}시 ${manse.day}일 ${manse.month}월 ${manse.year}년, 성별: ${gender}`;
-    const res = await fetch("/api/saju", {
+    const res = await fetch(`/api/saju?model=${encodeURIComponent(model)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ birthInfo, catMode, question: extraQuestion }),
@@ -101,7 +104,7 @@ export default function Home() {
       gender,
       report: resultText,
       catMode,
-      model: "gpt-5",
+      model,
       createdAt: new Date().toISOString(),
     };
     setResults((prev) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, Suspense } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import remarkSqueezeParagraphs from "remark-squeeze-paragraphs";
@@ -10,7 +10,7 @@ import ManseDisplay from "@/app/components/ManseDisplay";
 import CatRain from "@/app/components/CatRain";
 import { manseCalc } from "@/lib/manse";
 
-export default function Home() {
+function HomeContent() {
   const [name, setName] = useState("");
   const [birthDate, setBirthDate] = useState("");
   const [birthTime, setBirthTime] = useState("");
@@ -254,5 +254,13 @@ export default function Home() {
         </div>
       </div>
     </main>
+  );
+}
+
+export default function Home() {
+  return (
+    <Suspense fallback={<div />}> 
+      <HomeContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Parse `model` from `/api/saju` request URL and pass to OpenAI client
- Use `useSearchParams` on the client to forward `model` query and store it with results

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6898b0db8e808328bcaec5fedd3e2d77