### PR TITLE
Log API error responses

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,6 +98,8 @@ function HomeContent() {
         body: JSON.stringify({ birthInfo, catMode, question: extraQuestion }),
       });
       if (!res.ok) {
+        const errorText = await res.text();
+        console.error("API 응답 오류:", res.status, errorText);
         setError(
           catMode
             ? "요청이 실패했냥... 다시 시도해달라옹."


### PR DESCRIPTION
## Summary
- log server error responses during `/api/saju` fetches

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ad645c3bdc8328b9bef474e6e6ff36