### PR TITLE
Add optional web search parameter to Saju API

### DIFF
--- a/app/api/saju/route.ts
+++ b/app/api/saju/route.ts
@@ -5,6 +5,7 @@ export async function POST(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
     const model = searchParams.get("model") || "gpt-5-mini";
+    const search = searchParams.get("search") === "true";
     const { birthInfo, catMode, question } = await req.json();
     if (!birthInfo) {
       return NextResponse.json({ error: "Missing birthInfo" }, { status: 400 });
@@ -25,13 +26,13 @@ export async function POST(req: Request) {
         content: `${birthInfo}\n추가 질문: ${question}`,
       },
     ];
-    const response = await client.responses.create({
-      model,
-        tools: [
-        { type: "web_search_preview" },
-    ],
-      input: messages,
-    } as any);
+    const response = await client.responses.create(
+      {
+        model,
+        ...(search ? { tools: [{ type: "web_search_preview" }] } : {}),
+        input: messages,
+      } as any
+    );
 
     const output = response.output_text;
     return NextResponse.json({ result: output });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ function HomeContent() {
   const reportRef = useRef<HTMLDivElement>(null);
   const searchParams = useSearchParams();
   const model = searchParams.get("model") || "gpt-5-mini";
+  const search = searchParams.get("search") === "true";
   interface StoredResult {
     id: string;
     name: string;
@@ -92,7 +93,10 @@ function HomeContent() {
       setError(null);
       setLoading(true);
       const birthInfo = `${manse.hour}시 ${manse.day}일 ${manse.month}월 ${manse.year}년, 성별: ${gender}`;
-      const res = await fetch(`/api/saju?model=${encodeURIComponent(model)}`, {
+      const url = `/api/saju?model=${encodeURIComponent(model)}${
+        search ? "&search=true" : ""
+      }`;
+      const res = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ birthInfo, catMode, question: extraQuestion }),


### PR DESCRIPTION
## Summary
- read optional `search` query and append when calling `/api/saju`
- conditionally add `web_search_preview` tool in Saju API handler

## Testing
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ad79333c648328ac2534fd70c7d16f