### PR TITLE
Default LMT option to true

### DIFF
--- a/lib/manse.ts
+++ b/lib/manse.ts
@@ -428,7 +428,7 @@ function luckCyclesInfo(
   };
 }
 
-function manseCalc(y: number, m: number, d: number, hh: number, mm: number, tz: number, lon: number, useLmt = false) {
+function manseCalc(y: number, m: number, d: number, hh: number, mm: number, tz: number, lon: number, useLmt = true) {
   const JDutc = gregorianToJd(y, m, d, hh - tz, mm, 0);
   const gzYear = yearPillar(JDutc, y);
   const lam = sunEclipticLongitudeDeg(JDutc);
@@ -548,7 +548,8 @@ function parseRequestParams(url: URL) {
   const timeParam = url.searchParams.get('time') || '12:00';
   const tz = Number(url.searchParams.get('tz') ?? '9');
   const lon = Number(url.searchParams.get('lon') ?? '126.98');
-  const useLmt = ['true', '1', 'yes'].includes((url.searchParams.get('lmt') || '').toLowerCase());
+  const lmtParam = url.searchParams.get('lmt');
+  const useLmt = lmtParam === null ? true : ['true', '1', 'yes'].includes(lmtParam.toLowerCase());
   const cycle = Number(url.searchParams.get('cycle') ?? '10');
   const maleFlag = url.searchParams.get('male');
   const femaleFlag = url.searchParams.get('female');


### PR DESCRIPTION
## Summary
- default manse calculations to use local-mean-time correction when not specified
- allow query parameters to explicitly disable LMT by setting lmt to falsey values

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958516107d88328ab128d046c54ec2b)